### PR TITLE
deps: update wazero to v2.0.0 (pre-release)

### DIFF
--- a/internal/impl/wasm/processor_wazero.go
+++ b/internal/impl/wasm/processor_wazero.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/tetratelabs/wazero"
 	"github.com/tetratelabs/wazero/api"
+	"github.com/tetratelabs/wazero/experimental/opt"
 	"github.com/tetratelabs/wazero/imports/wasi_snapshot_preview1"
 
 	"github.com/benthosdev/benthos/v4/public/service"
@@ -99,7 +100,7 @@ func newWazeroAllocProcessor(functionName string, wasmBinary []byte, mgr *servic
 func (p *wazeroAllocProcessor) newModule() (mod *moduleRunner, err error) {
 	ctx := context.Background()
 
-	r := wazero.NewRuntime(ctx)
+	r := wazero.NewRuntimeWithConfig(ctx, opt.NewRuntimeConfigOptimizingCompiler())
 	mod = &moduleRunner{
 		log:     p.log,
 		runtime: r,


### PR DESCRIPTION
This draft updates [wazero](https://wazero.io/) to `main`, and flips the switch to the new advanced optimizing compiler that will be the default in v2.0.0.

Notably, this release introduces new features, such as experimental support to thread spec, and a new compilation pipeline that guarantees increased run-time performance for most workloads: in our tests, this amounts to at least a -30% run-time.